### PR TITLE
アロー関数にreturnをつける

### DIFF
--- a/src/services/vector.js
+++ b/src/services/vector.js
@@ -7,21 +7,17 @@ export default class Vector {
 
   // このベクトルを返す
   // return Array[3]
-  getValue = () => {
-    this.value
-  }
+  getValue = () => this.value
 
   // 逆向きのベクトルを返す
   // return Vector
-  negate = () => {
-    new Vector([-this.value[0], -this.value[1], -this.value[2]])
-  }
+  negate = () => new Vector([-this.value[0], -this.value[1], -this.value[2]])
 
   // vectorを引いたものを返す
   // params vector: Vector
   // return Vector
   sub = vector => {
-    new Vector([
+    return new Vector([
       this.value[0] - vector.getValue[0],
       this.value[1] - vector.getValue[1],
       this.value[2] - vector.getValue[2],
@@ -31,7 +27,7 @@ export default class Vector {
   // params n: Number
   // return Vector
   multiplyScalar = n => {
-    new Vector([this.value[0] * n, this.value[1] * n, this.value[2] * n])
+    return new Vector([this.value[0] * n, this.value[1] * n, this.value[2] * n])
   }
 
   // vectorとの内積を返す
@@ -39,15 +35,17 @@ export default class Vector {
   // return Number
   dot = vector => {
     const callback = (sum, component, i) => (sum += component * vector[i])
-    this.value.reduce(callback)
+    return this.value.reduce(callback)
   }
 
   // 絶対値の二乗を返す
   // return Number
   squaredLength = () => {
-    this.value[0] * this.value[0] +
+    return (
+      this.value[0] * this.value[0] +
       this.value[1] * this.value[1] +
       this.value[2] * this.value[2]
+    )
   }
 
   // vectorA-vectorBに垂直で0ベクトルを通るベクトルを返す


### PR DESCRIPTION
アロー関数を=> {}で書くとreturnが必要だったので修正

レビュー省略