### PR TITLE
setStateを使わない

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,21 +42,21 @@ class App extends React.Component {
     })
   }
 
-  updateBox = (index, box) => {
-    var boxes = Object.assign([], this.state.boxes)
-    boxes[index] = box
-    this.setState({
-      boxes: boxes,
-    })
-  }
+  // updateBox = (index, box) => {
+  //   var boxes = Object.assign([], this.state.boxes)
+  //   boxes[index] = box
+  //   this.setState({
+  //     boxes: boxes,
+  //   })
+  // }
 
-  updateBoxConfig = (index, boxConfig) => {
-    var boxConfigs = Object.assign([], this.state.boxConfigs)
-    boxConfigs[index] = boxConfig
-    this.setState({
-      boxConfigs: boxConfigs,
-    })
-  }
+  // updateBoxConfig = (index, boxConfig) => {
+  //   var boxConfigs = Object.assign([], this.state.boxConfigs)
+  //   boxConfigs[index] = boxConfig
+  //   this.setState({
+  //     boxConfigs: boxConfigs,
+  //   })
+  // }
 
   updateGeneralConfig = generalConfig => {
     this.setState({

--- a/src/components/Space.jsx
+++ b/src/components/Space.jsx
@@ -6,7 +6,7 @@ import { default as BoxInfo } from '../models/Box'
 
 function Space(props) {
   const boxes = props.boxes.map((box, i) => {
-    return <Box position={box.position} quaternion={box.quaternion} key={i} />
+    return <Box box={box} key={i} />
   })
 
   return (

--- a/src/components/editor/BoxTabPanel.jsx
+++ b/src/components/editor/BoxTabPanel.jsx
@@ -46,31 +46,24 @@ class BoxTabPanel extends React.Component {
       (newRotation[1] * Math.PI) / 180,
       (newRotation[2] * Math.PI) / 180,
     ])
-    const box = Object.assign({}, this.props.box)
-    box.rotation[i] = (newValue * Math.PI) / 180.0
-    box.quaternion[0] = quaternion[0]
-    box.quaternion[1] = quaternion[1]
-    box.quaternion[2] = quaternion[2]
-    box.quaternion[3] = quaternion[3]
-    this.props.updateBox(this.props.index, box)
+    this.props.box.rotation[i] = (newValue * Math.PI) / 180.0
+    // this.props.box.quaternion = quaternion
+    this.props.box.quaternion[0] = quaternion[0]
+    this.props.box.quaternion[1] = quaternion[1]
+    this.props.box.quaternion[2] = quaternion[2]
+    this.props.box.quaternion[3] = quaternion[3]
   }
 
   handleBoxRotationSliderCommit = i => (event, newValue) => {
-    const boxConfig = Object.assign({}, this.props.boxConfig)
-    boxConfig.initialRotation[i] = (newValue * Math.PI) / 180.0
-    this.props.updateBoxConfig(this.props.index, boxConfig)
+    this.props.boxConfig.initialRotation[i] = (newValue * Math.PI) / 180.0
   }
 
   handleBoxRotationInputChange = i => event => {
     const newValue = event.target.value
 
     if (isFinite(newValue)) {
-      const box = Object.assign({}, this.props.box)
-      box.rotation[i] = Number((newValue * Math.PI) / 180.0)
-      const boxConfig = Object.assign({}, this.props.boxConfig)
-      boxConfig.initialRotation[i] = Number((newValue * Math.PI) / 180.0)
-      this.props.updateBox(this.props.index, box)
-      this.props.updateBoxConfig(this.props.index, boxConfig)
+      this.props.box.rotation[i] = Number((newValue * Math.PI) / 180.0)
+      this.props.boxConfig.initialRotation[i] = Number((newValue * Math.PI) / 180.0)
     }
   }
 

--- a/src/components/editor/BoxTabPanel.jsx
+++ b/src/components/editor/BoxTabPanel.jsx
@@ -63,7 +63,9 @@ class BoxTabPanel extends React.Component {
 
     if (isFinite(newValue)) {
       this.props.box.rotation[i] = Number((newValue * Math.PI) / 180.0)
-      this.props.boxConfig.initialRotation[i] = Number((newValue * Math.PI) / 180.0)
+      this.props.boxConfig.initialRotation[i] = Number(
+        (newValue * Math.PI) / 180.0
+      )
     }
   }
 

--- a/src/components/editor/BoxTabPanel.jsx
+++ b/src/components/editor/BoxTabPanel.jsx
@@ -47,11 +47,7 @@ class BoxTabPanel extends React.Component {
       (newRotation[2] * Math.PI) / 180,
     ])
     this.props.box.rotation[i] = (newValue * Math.PI) / 180.0
-    // this.props.box.quaternion = quaternion
-    this.props.box.quaternion[0] = quaternion[0]
-    this.props.box.quaternion[1] = quaternion[1]
-    this.props.box.quaternion[2] = quaternion[2]
-    this.props.box.quaternion[3] = quaternion[3]
+    this.props.box.quaternion = quaternion
   }
 
   handleBoxRotationSliderCommit = i => (event, newValue) => {
@@ -74,27 +70,19 @@ class BoxTabPanel extends React.Component {
     newPosition[i] = newValue
     this.setState({ initialPosition: newPosition })
 
-    const box = Object.assign({}, this.props.box)
-    box.position[i] = newValue
-    this.props.updateBox(this.props.index, box)
+    this.props.box.position[i] = newValue
   }
 
   handleBoxPositionSliderCommit = i => (event, newValue) => {
-    const boxConfig = Object.assign({}, this.props.boxConfig)
-    boxConfig.initialPosition[i] = newValue
-    this.props.updateBoxConfig(this.props.index, boxConfig)
+    this.props.boxConfig.initialPosition[i] = newValue
   }
 
   handleBoxPositionInputChange = i => event => {
     const newValue = event.target.value
 
     if (isFinite(newValue)) {
-      const box = Object.assign({}, this.props.box)
-      box.position[i] = Number(newValue)
-      const boxConfig = Object.assign({}, this.props.boxConfig)
-      boxConfig.initialPosition[i] = Number(newValue)
-      this.props.updateBox(this.props.index, box)
-      this.props.updateBoxConfig(this.props.index, boxConfig)
+      this.props.box.position[i] = Number(newValue)
+      this.props.boxConfig.initialPosition[i] = Number(newValue)
     }
   }
 
@@ -102,19 +90,16 @@ class BoxTabPanel extends React.Component {
     const newValue = event.target.value
 
     if (this.NumberRegExpPattern.test(newValue)) {
-      const box = Object.assign({}, this.props.box)
-      box.velocity[i] = Number(newValue) * this.props.boxConfig.standardVelocity
-      const boxConfig = Object.assign({}, this.props.boxConfig)
-      boxConfig.initialVelocity[i] =
+      const initialVelocity =
         Number(newValue) * this.props.boxConfig.standardVelocity
-      this.props.updateBox(this.props.index, box)
-      this.props.updateBoxConfig(this.props.index, boxConfig)
+      this.props.box.velocity[i] = initialVelocity
+      this.props.boxConfig.initialVelocity[i] = initialVelocity
 
-      const initialVelocity = Object.assign([], this.state.initialVelocity)
-      initialVelocity[i] = newValue
+      const initialVelocityState = Object.assign([], this.state.initialVelocity)
+      initialVelocityState[i] = newValue
       const error = Object.assign({}, this.state.error)
       error.velocity[i] = false
-      this.setState({ initialVelocity: initialVelocity, error: error })
+      this.setState({ initialVelocity: initialVelocityState, error: error })
     } else {
       const initialVelocity = Object.assign([], this.state.initialVelocity)
       initialVelocity[i] = newValue
@@ -128,19 +113,12 @@ class BoxTabPanel extends React.Component {
     const newValue = event.target.value
 
     if (this.NumberRegExpPattern.test(newValue)) {
-      const box = Object.assign({}, this.props.box)
-      const boxConfig = Object.assign({}, this.props.boxConfig)
-      boxConfig.initialRotVelocity[i] =
+      this.props.boxConfig.initialRotVelocity[i] =
         Number(newValue) * this.props.boxConfig.standardRotVelocity
       const quaternion = Calculation.eulerToQuaternion(
-        boxConfig.initialRotVelocity
+        this.props.boxConfig.initialRotVelocity
       )
-      box.quatVelocity[0] = quaternion[0]
-      box.quatVelocity[1] = quaternion[1]
-      box.quatVelocity[2] = quaternion[2]
-      box.quatVelocity[3] = quaternion[3]
-      this.props.updateBox(this.props.index, box)
-      this.props.updateBoxConfig(this.props.index, boxConfig)
+      this.props.box.quatVelocity = quaternion
 
       const initialRotVelocity = Object.assign(
         [],
@@ -167,9 +145,7 @@ class BoxTabPanel extends React.Component {
 
     this.setState({ fixed: newValue })
 
-    const boxConfig = Object.assign({}, this.props.boxConfig)
-    boxConfig.fixed = newValue
-    this.props.updateBoxConfig(this.props.index, boxConfig)
+    this.props.boxConfig.fixed = newValue
   }
 
   render() {

--- a/src/components/objects/Box.jsx
+++ b/src/components/objects/Box.jsx
@@ -27,5 +27,5 @@ export default function Box(props) {
 }
 
 Box.propTypes = {
-  box: PropTypes.instanceOf(BoxInfo)
+  box: PropTypes.instanceOf(BoxInfo),
 }

--- a/src/components/objects/Box.jsx
+++ b/src/components/objects/Box.jsx
@@ -2,18 +2,20 @@ import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useFrame } from 'react-three-fiber'
 import Calculation from '../../services/Calculation'
+import { default as BoxInfo } from '../../models/Box'
 
-function Box(props) {
+export default function Box(props) {
   const mesh = useRef()
 
   useFrame(() => {
-    const euler = Calculation.quaternionToEuler(props.quaternion)
+    const euler = Calculation.quaternionToEuler(props.box.quaternion)
+    const position = props.box.position
     mesh.current.rotation.x = euler[0]
     mesh.current.rotation.y = euler[1]
     mesh.current.rotation.z = euler[2]
-    mesh.current.position.x = props.position[0]
-    mesh.current.position.y = props.position[1]
-    mesh.current.position.z = props.position[2]
+    mesh.current.position.x = position[0]
+    mesh.current.position.y = position[1]
+    mesh.current.position.z = position[2]
   })
 
   return (
@@ -25,8 +27,5 @@ function Box(props) {
 }
 
 Box.propTypes = {
-  position: PropTypes.arrayOf(PropTypes.number),
-  quaternion: PropTypes.arrayOf(PropTypes.number),
+  box: PropTypes.instanceOf(BoxInfo)
 }
-
-export default Box

--- a/src/services/Calculation.js
+++ b/src/services/Calculation.js
@@ -153,13 +153,15 @@ class Calculation {
   }
 
   static updateValues = (boxes, boxConfigs, gravity) => {
-    boxes.forEach((boxA, index) => {
-      for (var i = index + 1; boxes.length; i++) {
-        const boxB = boxes[i]
-        // boxAとboxBの衝突を調べる
-        boxA.isClash(boxB)
-      }
-    })
+    if (boxes.length > 1) {
+      boxes.forEach((boxA, index) => {
+        for (var i = index + 1; boxes.length; i++) {
+          const boxB = boxes[i]
+          // boxAとboxBの衝突を調べる
+          boxA.isClash(boxB)
+        }
+      })
+    }
 
     boxes.forEach((box, index) => {
       // 速度の更新


### PR DESCRIPTION
box.quaternionを更新しても画面に反映されなかった問題を修正

setStateは使わずpropsを直接書き直すことで、画面のレンダリングを禁止していてもthree.jsに渡す値を更新する

レビュー省略