### PR TITLE
サポート座標の計算は全てグローバルな座標で十分だった

### DIFF
--- a/src/components/objects/DebugObject.jsx
+++ b/src/components/objects/DebugObject.jsx
@@ -11,7 +11,7 @@ export default function DebugObject({ thisBox, targetBox, index, visibles }) {
 
   useFrame(() => {
     const euler = thisBox.quaternion.toEuler()
-    const position = targetBox.vertexPosition[index]
+    const position = targetBox.vertexPositions[index]
     mesh.current.visible = visibles.debugObjects
     mesh.current.rotation.x = euler[0]
     mesh.current.rotation.y = euler[1]

--- a/src/models/Box.js
+++ b/src/models/Box.js
@@ -27,7 +27,11 @@ export default class Box {
   // params box: models/Box
   isClash = box => {
     // https://trap.jp/post/198/ GJKアルゴリズム 3次元の場合を参照
-    const p0 = new Vector(box.position) // p0はboxの重心を使うことにする
+    let p0 = new Vector(box.position) // p0はboxの重心を使うことにする
+    if (p0.isZero()) {
+      p0 = new Vector(box.vertexPositions[0])
+    }
+
     const v1 = p0.negate()
     const p1 = this.supportMapping(v1).sub(
       box.supportMapping(p0)
@@ -46,10 +50,22 @@ export default class Box {
     let vectors = [p0, p1, p2]
     let clash = false
     while (true) {
+      // vectorsに0ベクトルが含まれているとバグる可能性があるので即trueを返す
+      if (vectors.some(vector => vector.isZero())) {
+        clash = true
+        break
+      }
+
       const vertical = Vector.verticalVector3(...vectors)
       const newP = this.supportMapping(vertical).sub(
         box.supportMapping(vertical.negate())
       )
+
+      if (newP.isZero()) {
+        clash = true
+        break
+      }
+
       if (vertical.dot(newP) < 0) {
         clash = false
         break
@@ -62,7 +78,7 @@ export default class Box {
         const triangle = array.filter((item, index) => index !== i)
         const vertical3 = Vector.verticalVector3(...triangle)
 
-        return vertical3.dot(v) > 0
+        return vertical3.dot(v) >= 0
       })
 
       if (vectors.length === 4) {

--- a/src/models/Box.js
+++ b/src/models/Box.js
@@ -33,16 +33,12 @@ export default class Box {
     }
 
     const v1 = p0.negate()
-    const p1 = this.supportMapping(v1).sub(
-      box.supportMapping(p0)
-    ) // v1方向の、ミンコフスキー差のサポート写像
+    const p1 = this.supportMapping(v1).sub(box.supportMapping(p0)) // v1方向の、ミンコフスキー差のサポート写像
     if (v1.dot(p1) < 0) {
       return false
     }
     const v2 = Vector.verticalVector2(p0, p1)
-    const p2 = this.supportMapping(v2).sub(
-      box.supportMapping(v2.negate())
-    )
+    const p2 = this.supportMapping(v2).sub(box.supportMapping(v2.negate()))
     if (v2.dot(p2) < 0) {
       return false
     }

--- a/src/models/Box.js
+++ b/src/models/Box.js
@@ -11,7 +11,7 @@ export default class Box {
     this.rotVelocity = [0, 0, 0]
     this.quaternion = new Quaternion([1, 0, 0, 0])
     this.quatVelocity = new Quaternion([1, 0, 0, 0])
-    this.vertexPosition = [
+    this.vertexPositions = [
       [0, 0, 0],
       [0, 0, 0],
       [0, 0, 0],
@@ -125,33 +125,33 @@ export default class Box {
   // params box: models/Box
   // return Array[Array]
   getRelativeVertexPositions = (position, quaternion) => {
-    let nVertexPosition = []
+    let nVertexPositions = []
     for (let i = 0; i < 8; i++) {
-      let vertexTranslation = this.vertexPosition[i].map((element, index) => {
+      let vertexTranslation = this.vertexPositions[i].map((element, index) => {
         return element - position[index]
       })
       let mVertexPosition = Calculation.inverseRotationalTranslate(
         quaternion,
         vertexTranslation
       )
-      nVertexPosition.push(mVertexPosition)
+      nVertexPositions.push(mVertexPosition)
     }
-    return nVertexPosition
+    return nVertexPositions
   }
 
-  // vertexPositionを更新する
+  // vertexPositionsを更新する
   updateVertexPositions = () => {
-    let localVertexPosition = this.getLocalVertexPositions()
+    let localVertexPositions = this.getLocalVertexPositions()
 
-    let nVertexPosition = []
+    let nVertexPositions = []
     for (let i = 0; i < 8; i++) {
       let vertexTranslation = Calculation.rotationalTranslate(
         this.quaternion,
-        localVertexPosition[i]
+        localVertexPositions[i]
       ).map((element, index) => this.position[index] + element)
-      nVertexPosition.push(vertexTranslation)
+      nVertexPositions.push(vertexTranslation)
     }
 
-    this.vertexPosition = nVertexPosition
+    this.vertexPositions = nVertexPositions
   }
 }

--- a/src/services/vector.js
+++ b/src/services/vector.js
@@ -9,6 +9,23 @@ export default class Vector {
   // return Array[3]
   getValue = () => this.value
 
+  // 同じベクトルかどうかを返す
+  // params vector: Vector
+  // return boolean
+  equal = vector => {
+    return (
+      this.value[0] === vector.value[0] &&
+      this.value[1] === vector.value[1] &&
+      this.value[2] === vector.value[2]
+    )
+  }
+
+  // このベクトルがゼロベクトルかどうかを返す
+  // return boolean
+  isZero = () => {
+    return this.value[0] === 0 && this.value[1] === 0 && this.value[2] === 0
+  }
+
   // 逆向きのベクトルを返す
   // return Vector
   negate = () => new Vector([-this.value[0], -this.value[1], -this.value[2]])
@@ -73,10 +90,17 @@ export default class Vector {
   }
 
   // vectorA-vectorBに垂直で0ベクトルを通るベクトルを返す
+  // vectorA, vectorBとの内積が共に負の方向のベクトルを返す
+  // 大きさは1とは限らない
   // params vectorA: Vector
   // params vectorB: Vector
   // return Vector
   static verticalVector2 = (vectorA, vectorB) => {
+    // vectorA = vectorBのときは、vectorAの逆ベクトルを返す
+    if (vectorA.equal(vectorB)) {
+      return vectorA.negate()
+    }
+
     // vectorA, vectorBを1-s:sで内分した点から0ベクトルへむかうベクトルを計算する
     const s =
       vectorB.sub(vectorA).dot(vectorB) / vectorB.sub(vectorA).squaredLength()
@@ -87,12 +111,23 @@ export default class Vector {
     return vertical
   }
 
-  // vectorA, vectorB, vectorCに垂直で0ベクトルを通るベクトルを返す
+  // vectorA, vectorB, vectorCの作る面に垂直で0ベクトルを通るベクトルを返す
+  // vectorA, vectorB, vectorCとの内積が全て負の方向のベクトルを返す
+  // 大きさは1とは限らない
   // params vectorA: Vector
   // params vectorB: Vector
   // params vectorC: Vector
   // return Vector
   static verticalVector3 = (vectorA, vectorB, vectorC) => {
+    // vectorA, vectorB, vectorCのうち、等しいものがあった時の処理
+    if (vectorA.equal(vectorB)) {
+      return Vector.verticalVector2(vectorB, vectorC)
+    } else if (vectorB.equal(vectorC)) {
+      return Vector.verticalVector2(vectorC, vectorA)
+    } else if (vectorC.equal(vectorA)) {
+      return Vector.verticalVector2(vectorA, vectorB)
+    }
+
     let vertical = vectorB.sub(vectorA).cross(vectorC.sub(vectorA))
     if (vertical.dot(vectorA) > 0) {
       vertical = vertical.negate()


### PR DESCRIPTION
片方の直方体から見たもう片方の直方体の頂点座標(相対座標)を用いてミンコフスキ差を考えていたが
よくよく考えると普通にグローバル座標で考えれば十分だった

- 動作確認などで面倒だったので、全て修正した
- いくつかの値が0ベクトルになったり、平面上に複数の点が乗ることでバグが発生していたので修正した
- box.vertexPositionは複数の座標の配列なので、複数形にリファクタをした

### テスト
- [x] 二つの立方体を表示、上下に移動させて下の方を固定。アニメーションを再生してぶつかる時もエラーが出ない